### PR TITLE
fix no valid addresses caused by lack of  ip's version

### DIFF
--- a/pkg/hns/endpoint_windows.go
+++ b/pkg/hns/endpoint_windows.go
@@ -128,10 +128,10 @@ func ConstructResult(hnsNetwork *hcsshim.HNSNetwork, hnsEndpoint *hcsshim.HNSEnd
 	var ipVersion string
 	if ipv4 := hnsEndpoint.IPAddress.To4(); ipv4 != nil {
 		ipVersion = "4"
-	} else if ipv6 := hnsEndpoint.Address.To16(); ipv6 != nil {
+	} else if ipv6 := hnsEndpoint.IPAddress.To16(); ipv6 != nil {
 		ipVersion = "6"
 	} else {
-		return nil, fmt.Errorf("the Address of hnsEndpoint isn't a valid ipv4 or ipv6 Address.")
+		return nil, fmt.Errorf("the IPAddress of hnsEndpoint isn't a valid ipv4 or ipv6 Address.")
 	}
 
 	resultIPConfig := &current.IPConfig{

--- a/pkg/hns/endpoint_windows.go
+++ b/pkg/hns/endpoint_windows.go
@@ -131,7 +131,7 @@ func ConstructResult(hnsNetwork *hcsshim.HNSNetwork, hnsEndpoint *hcsshim.HNSEnd
 	} else if ipv6 := hnsEndpoint.IPAddress.To16(); ipv6 != nil {
 		ipVersion = "6"
 	} else {
-		return nil, fmt.Errorf("the IPAddress of hnsEndpoint isn't a valid ipv4 or ipv6 Address.")
+		return nil, fmt.Errorf("[win-cni] The IPAddress of hnsEndpoint isn't a valid ipv4 or ipv6 Address.")
 	}
 
 	resultIPConfig := &current.IPConfig{

--- a/pkg/hns/endpoint_windows.go
+++ b/pkg/hns/endpoint_windows.go
@@ -17,11 +17,13 @@
 package hns
 
 import (
-	"github.com/Microsoft/hcsshim"
-	"github.com/containernetworking/cni/pkg/types/current"
+	"fmt"
 	"log"
 	"net"
 	"strings"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/containernetworking/cni/pkg/types/current"
 )
 
 // ConstructEndpointName constructs enpointId which is used to identify an endpoint from HNS
@@ -123,7 +125,17 @@ func ConstructResult(hnsNetwork *hcsshim.HNSNetwork, hnsEndpoint *hcsshim.HNSEnd
 		return nil, err
 	}
 
+	var ipVersion string
+	if ipv4 := hnsEndpoint.IPAddress.To4(); ipv4 != nil {
+		ipVersion = "4"
+	} else if ipv6 := hnsEndpoint.Address.To16(); ipv6 != nil {
+		ipVersion = "6"
+	} else {
+		return nil, fmt.Errorf("the Address of hnsEndpoint isn't a valid ipv4 or ipv6 Address.")
+	}
+
 	resultIPConfig := &current.IPConfig{
+		Version: ipVersion,
 		Address: net.IPNet{
 			IP:   hnsEndpoint.IPAddress,
 			Mask: ipSubnet.Mask},


### PR DESCRIPTION
I build the win-overlay.exe from the windowsCni branch. but the winoverlay.exe couldn't  create the PodSandbox even though it can correctly create hnsendpoints in the vxlan0 overlay network when I 
create a deployment resource on my linux master node.

the last step of cmdAdd is printing result. the [types.PrintResult](https://github.com/rakelkar/plugins/blob/windowsCni/vendor/github.com/containernetworking/cni/pkg/types/types.go#L100) finally call this convertTo020 func to get a types020.Result. However this [hns.ConstructResult(hnsNetwork, hnsEndpoint)](https://github.com/rakelkar/plugins/blob/windowsCni/pkg/hns/endpoint_windows.go#L126) forgot to add the ip's version for current.IPConfig, so we got the err  "no valid addresses".




